### PR TITLE
librfm3: i2c_ctx: Fixed I2C read for reads > 1 byte

### DIFF
--- a/librfm3/src/i2c_ctx.c
+++ b/librfm3/src/i2c_ctx.c
@@ -163,7 +163,7 @@ pt_state_t i2c_ctx_sendaddr(i2c_ctx_t *c, uint16_t addr,
 	if (c->bytes_remaining == 1)
 		I2C_CR1(c->i2c) &= ~I2C_CR1_ACK;
 	else if (c->bytes_remaining >= 2)
-		I2C_CR1(c->i2c) |= ~I2C_CR1_ACK;
+		I2C_CR1(c->i2c) |= I2C_CR1_ACK;
 
 	/* Read sequence has side effect or clearing I2C_SR1_ADDR */
 	uint32_t reg32 __attribute__((unused));


### PR DESCRIPTION
I was having trouble using this code with a TI TMP102 temperature sensor, where it would stop reading after sending the address + read. After looking at the signals with a logic analyzer, it appeared that the STM32 wasn't transmitting the clock at all, which explained why the reads were failing. After some more investigation, I traced the issue back to this single flag inversion. Since temperature reads from the TMP102 are two bytes wide, the code would branch to what should have been an ACK-enable, but the inverted flag would enable every other flag instead. Getting rid of that one tilde fixed the whole issue, and now it works perfectly.