### PR TITLE
Use cortex-m-generic.ld instead of libopencm3_stm32f4.ld

### DIFF
--- a/src/bootloader/lctech-f103.ld
+++ b/src/bootloader/lctech-f103.ld
@@ -28,5 +28,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
-
+INCLUDE cortex-m-generic.ld

--- a/src/lctech-f103.ld
+++ b/src/lctech-f103.ld
@@ -28,5 +28,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
-
+INCLUDE cortex-m-generic.ld

--- a/src/stm32f4-discovery.ld
+++ b/src/stm32f4-discovery.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld
 


### PR DESCRIPTION
fixes #6

this is an upstream change in libopencm3, there's no libopencm3_stm32f4.ld but cortex-m-generic.ld