### PR TITLE
added support for maplemini board

### DIFF
--- a/src/bootloader/usbdfu.c
+++ b/src/bootloader/usbdfu.c
@@ -244,6 +244,15 @@ static usbd_device *usb_init(void)
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
 		      GPIO11 | GPIO12);
 	gpio_clear(GPIOA, GPIO11 || GPIO12);
+
+#ifdef USE_MAPLEMINI
+	/* add support for Maplemini board */
+	rcc_periph_clock_enable(RCC_GPIOB);
+	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
+		      GPIO9);
+	gpio_clear(GPIOB, GPIO9);
+#endif
+
 	t = time_now() + 10000;
 	while (cyclecmp32(time_now(), t) < 0)
 		;

--- a/src/i2c-stm32f1-usb/i2c-stm32f1-usb.c
+++ b/src/i2c-stm32f1-usb/i2c-stm32f1-usb.c
@@ -328,6 +328,15 @@ static int usb_fibre(fibre_t *fibre)
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
 		      GPIO11 | GPIO12);
 	gpio_clear(GPIOA, GPIO11 | GPIO12);
+
+#ifdef USE_MAPLEMINI
+	/* add support for Maplemini board */
+	rcc_periph_clock_enable(RCC_GPIOB);
+	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL,
+		      GPIO9);
+	gpio_clear(GPIOB, GPIO9);
+#endif
+
 	t = time_now() + 10000;
 	PT_WAIT_UNTIL(fibre_timeout(t));
 


### PR DESCRIPTION
Hi,
I found this project while looking for STM32 based i2c-tiny-usb alternatives. Since I only had a couple of maplemini boards on stock at home, I tried to execute your code directly with no success. Even though the used board (with an STM32F103CBT6 µC) is comparable and similarly wired (wr. to the USB pins), I wasn't able to establish a USB connection. After comparing the schematics for "bluepill" and "maplemini" based development boards I realized, that the maplemini uses GPIOB9 to disable USB connectivity through a transistor on USBDP. The bluepill board directly uses a pull up resistor on USBDP. Configuring GPIOB9 as output and clearing it afterwards, brought me success :-)
I encapsulated my changes in an #ifdef, such that the code needs to be build with CFLAGS=-DUSE_MAPLEMINI in order to include my changes.  Feel free to merge, if you are interested :-)

BR
Matthias